### PR TITLE
update direction directive

### DIFF
--- a/R/09_flow_view_deps.R
+++ b/R/09_flow_view_deps.R
@@ -70,7 +70,7 @@ flow_view_deps <- function(
   show_imports <- match.arg(show_imports)
 
   nomnoml_setup <- c(
-    "# direction: right",
+    "#direction: right",
     "#.expfun: visual=roundrect fill=#ddebf7 title=bold",
     "#.unexpfun: visual=roundrect fill=#fff2cc title=bold",
     "#.trimmed: visual=roundrect fill=#fce4d6 dashed title=bold",

--- a/R/10_flow_view_vars.R
+++ b/R/10_flow_view_vars.R
@@ -324,7 +324,7 @@ flow_view_vars..format_deps <- function(var_deps, fun_name, fun_args, expand) {
 
 flow_view_vars..build_nomnoml_code <- function(df, fun_name, fun_args) {
   nomnoml_code <- "
-# direction: down
+#direction: down
 #.fun: visual=roundrect fill=#ddebf7 title=bold
 #.arg: visual=roundrect fill=#e2efda title=bold
 #.var: visual=roundrect fill=#f0f0f0 title=bold

--- a/R/13_flow_view_uses.R
+++ b/R/13_flow_view_uses.R
@@ -66,7 +66,7 @@ flow_view_uses <- function(x, pkg = NULL, out = NULL) {
   if (identical(out, "data")) return(data)
 
   nomnoml_setup <- c(
-    "# direction: right",
+    "#direction: right",
     "#.expfun: visual=roundrect fill=#ddebf7 title=bold",
     "#.unexpfun: visual=roundrect fill=#fff2cc title=bold",
     "#.trimmed: visual=roundrect fill=#fce4d6 dashed title=bold",

--- a/tests/testthat/_snaps/10_flow_view_vars.md
+++ b/tests/testthat/_snaps/10_flow_view_vars.md
@@ -3,7 +3,7 @@
     Code
       flow_view_vars(ave, out = "code")
     Output
-      [1] "\n# direction: down\n#.fun: visual=roundrect fill=#ddebf7 title=bold\n#.arg: visual=roundrect fill=#e2efda title=bold\n#.var: visual=roundrect fill=#f0f0f0 title=bold\n#.newvar: visual=roundrect fill=#fff2cc title=bold\n#.return: visual=end fill=#70ad47  empty\n#.deadcode: visual=roundrect fill=#fce4d6 dashed title=bold\n[<fun> ave] -> [<arg> x]\n[<fun> ave] -> [<arg> ...]\n[<fun> ave] -> [<arg> FUN]\n[<arg> FUN] -> [<var> x*]\n[<arg> x] -> [<var> x*]\n[<arg> x] -> [<var> x*]\n[<arg> ...] --> [<var> x*]\n[<arg> ...] -> [<var> g]\n[<arg> x] -> [<var> x**]\n[<var> g] -> [<var> x**]\n[<arg> FUN] -> [<var> x**]\n[<arg> x] -> [<var> x**]\n[<arg> ...] --> [<var> x**]\n[<var> x*] -> [<var> x***]\n[<var> x**] -> [<var> x***]\n[<var> x***] -> [<return> *OUT*]"
+      [1] "\n#direction: down\n#.fun: visual=roundrect fill=#ddebf7 title=bold\n#.arg: visual=roundrect fill=#e2efda title=bold\n#.var: visual=roundrect fill=#f0f0f0 title=bold\n#.newvar: visual=roundrect fill=#fff2cc title=bold\n#.return: visual=end fill=#70ad47  empty\n#.deadcode: visual=roundrect fill=#fce4d6 dashed title=bold\n[<fun> ave] -> [<arg> x]\n[<fun> ave] -> [<arg> ...]\n[<fun> ave] -> [<arg> FUN]\n[<arg> FUN] -> [<var> x*]\n[<arg> x] -> [<var> x*]\n[<arg> x] -> [<var> x*]\n[<arg> ...] --> [<var> x*]\n[<arg> ...] -> [<var> g]\n[<arg> x] -> [<var> x**]\n[<var> g] -> [<var> x**]\n[<arg> FUN] -> [<var> x**]\n[<arg> x] -> [<var> x**]\n[<arg> ...] --> [<var> x**]\n[<var> x*] -> [<var> x***]\n[<var> x**] -> [<var> x***]\n[<var> x***] -> [<return> *OUT*]"
     Code
       flow_view_vars(ave, out = "data")
     Output


### PR DESCRIPTION
I noticed that with a recent update to the nomnoml package, the direction always went downards regardless of the `# direction: right` directive. I realised that the documentation had no space between the hash and directive. When I fixed the code in the widget, displayed correctly.